### PR TITLE
add uglify with harmony after build

### DIFF
--- a/config/webpack.config.prod.js
+++ b/config/webpack.config.prod.js
@@ -25,8 +25,8 @@ module.exports = {
   entry: path.join(srcPath, 'index'),
   output: {
     path: buildPath,
-    filename: '[name].[chunkhash].js',
-    chunkFilename: '[name].[chunkhash].chunk.js',
+    filename: '[name].js',
+    chunkFilename: '[name].chunk.js',
     // TODO: this wouldn't work for e.g. GH Pages.
     // Good news: we can infer it from package.json :-)
     publicPath: '/'

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babel-plugin-syntax-decorators": "^6.13.0",
     "babel-plugin-syntax-trailing-function-commas": "6.8.0",
     "babel-plugin-transform-class-properties": "6.10.2",
-    "babel-plugin-transform-decorators-legacy": "1.3.4",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "babel-plugin-transform-object-rest-spread": "6.8.0",
     "babel-plugin-transform-react-constant-elements": "6.9.1",
     "babel-plugin-transform-runtime": "^6.3.13",
@@ -41,6 +41,7 @@
     "eslint-plugin-import": "2.2.0",
     "eslint-plugin-node": "4.2.2",
     "eslint-plugin-react": "6.10.3",
+    "eslint-plugin-standard": "^3.0.1",
     "ether-pudding": "^3.1.2",
     "ethereumjs-testrpc": "3.0.3",
     "extract-text-webpack-plugin": "1.0.1",
@@ -96,6 +97,7 @@
     "truffle": "3.1.2",
     "truffle-require": "0.0.3",
     "truffle-solidity-loader": "0.0.8",
+    "uglify-js": "github:mishoo/UglifyJS2#harmony",
     "underscore": "1.8.3",
     "url-loader": "0.5.7",
     "web3": "^0.17.0-alpha",
@@ -104,7 +106,6 @@
     "webpack-dev-server": "1.14.1"
   },
   "dependencies": {
-    "babel-plugin-transform-decorators-legacy": "^1.3.4",
     "bignumber.js": "^4.0.0",
     "bip39": "^2.2.0",
     "bluebird": "^3.4.7",
@@ -144,7 +145,7 @@
   "scripts": {
     "start": "node ./scripts/start.js",
     "stats": "node ./scripts/start.js --stats",
-    "build": "node ./scripts/build.js",
+    "build": "node ./scripts/build.js && uglifyjs build/main.js -o 'build/main.js' -c 'drop_console:true'",
     "test": "standard --fix './*.js' 'src/**/*.js' 'specs/**/*.js' 'setup/**/*.js' 'scripts/**/*.js' 'config/**/*.js' && jest --forceExit --runInBand",
     "test:watch": "npm test -- --watch"
   },


### PR DESCRIPTION
I had to delete hash from main.js in build for runing uglify after build process

add eslint-plugin-standard to dependencies

for run build as it was before use use:
node ./scripts/build.js