### PR TITLE
MINT-23 add all LH transactions table to lh_story

### DIFF
--- a/setup/4_setup_assets.js
+++ b/setup/4_setup_assets.js
@@ -161,7 +161,7 @@ module.exports = () => {
       return chronoBankPlatform.changeOwnership(SYMBOL, ContractsManager.address, params)
     }).then(r => {
       console.log(r)
-      return chronoBankPlatform.issueAsset(SYMBOL2, 0, NAME2, DESCRIPTION2, BASE_UNIT, IS_REISSUABLE, {
+      return chronoBankPlatform.issueAsset(SYMBOL2, 300, NAME2, DESCRIPTION2, BASE_UNIT, IS_REISSUABLE, {
         from: accounts[0],
         gas: 3000000
       })

--- a/specs/redux/lhStory/lhStory.spec.js
+++ b/specs/redux/lhStory/lhStory.spec.js
@@ -1,10 +1,11 @@
 import configureMockStore from 'redux-mock-store'
 import thunk from 'redux-thunk'
-import {List} from 'immutable'
+import {List, Map} from 'immutable'
 import reducer, * as actions from '../../../src/redux/lhStory/lhStory'
 
 const mockStore = configureMockStore([thunk])
 let store = null
+const toBlock = Math.random()
 
 let list = new List()
 list = list.set(0, 'Abc')
@@ -19,9 +20,7 @@ describe('lhStory', () => {
   it('should return the initial state', () => {
     expect(
       reducer(undefined, {})
-    ).toEqual({
-      list: new List()
-    })
+    ).toEqual(actions.initialState)
   })
 
   it('should handle LH_STORY_LIST', () => {
@@ -32,10 +31,41 @@ describe('lhStory', () => {
     })
   })
 
+  it('should handle LH_STORY_TRANSACTIONS_FETCH', () => {
+    expect(
+      reducer(actions.initialState, {type: actions.LH_STORY_TRANSACTIONS_FETCH})
+    ).toEqual({
+      ...actions.initialState,
+      isFetching: true
+    })
+  })
+
+  it('should handle LH_STORY_TRANSACTIONS', () => {
+    expect(
+      reducer(actions.initialState, {type: actions.LH_STORY_TRANSACTIONS, map: new Map(), toBlock})
+    ).toEqual({
+      ...actions.initialState,
+      isFetching: false,
+      toBlock
+    })
+  })
+
   it('should list lh story', () => {
     store.dispatch(actions.listStory())
     expect(store.getActions()).toEqual([
       {type: actions.LH_STORY_LIST, list: store.getActions()[0].list}
     ])
+  })
+
+  it('should load lh transactios', () => {
+    store.dispatch(actions.getLHTransactions('all', toBlock))
+    expect(store.getActions()).toEqual([
+      { 'type': actions.LH_STORY_TRANSACTIONS_FETCH }
+    ])
+  })
+
+  it('should load lh transactios', () => {
+    store.dispatch(actions.getLHTransactions('all', toBlock))
+    expect(require('../../../src/redux/lhStory').lhStory).toEqual(reducer)
   })
 })

--- a/src/components/common/TransactionsWidget.js
+++ b/src/components/common/TransactionsWidget.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react'
-import { connect } from 'react-redux'
 import {
   Paper,
   Divider,
@@ -13,9 +12,9 @@ import {
   RaisedButton,
   CircularProgress
 } from 'material-ui'
-import { getTransactionsByAccount } from '../../../redux/wallet/actions'
+// import { getTransactionsByAccount } from '../redux/wallet/actions'
 
-import globalStyles from '../../../styles'
+import globalStyles from '../../styles'
 
 const styles = {
   columns: {
@@ -34,20 +33,9 @@ const styles = {
   }
 }
 
-const mapStateToProps = (state) => ({
-  transactions: state.get('wallet').transactions,
-  toBlock: state.get('wallet').toBlock,
-  isFetching: state.get('wallet').isFetching
-})
-
-const mapDispatchToProps = (dispatch) => ({
-  getTransactions: (toBlock = null) => dispatch(getTransactionsByAccount(window.localStorage.account, toBlock))
-})
-
-@connect(mapStateToProps, mapDispatchToProps)
 class TransactionsWidget extends Component {
   componentWillMount () {
-    this.props.getTransactions()
+    this.props.getTransactions(null, this.props.isAllLH)
   }
 
   handleLoadMore = () => {
@@ -57,8 +45,8 @@ class TransactionsWidget extends Component {
   render () {
     return (
       <Paper style={globalStyles.paper} zDepth={1} rounded={false}>
-        <h3 style={globalStyles.title}>Transactions</h3>
-        <Divider style={{backgroundColor: globalStyles.title.color}} />
+        <h3 style={globalStyles.title}>{this.props.title || 'Transactions'}</h3>
+        <Divider style={{ backgroundColor: globalStyles.title.color }} />
         <Table selectable={false}>
           <TableHeader adjustForCheckbox={false} displaySelectAll={false}>
             <TableRow>
@@ -91,8 +79,8 @@ class TransactionsWidget extends Component {
             </TableRow>) : ''}
             {this.props.isFetching
               ? (<TableRow key='loader'>
-                <TableRowColumn style={{width: '100%', textAlign: 'center'}} colSpan={4}>
-                  <CircularProgress style={{margin: '0 auto'}} size={24} thickness={1.5} />
+                <TableRowColumn style={{ width: '100%', textAlign: 'center' }} colSpan={4}>
+                  <CircularProgress style={{ margin: '0 auto' }} size={24} thickness={1.5} />
                 </TableRowColumn>
               </TableRow>) : null}
           </TableBody>

--- a/src/components/pages/WalletPage/index.js
+++ b/src/components/pages/WalletPage/index.js
@@ -1,9 +1,7 @@
 import SendWidget from './SendWidget'
 import BalancesWidget from './BalancesWidget'
-import TransactionsWidget from './TransactionsWidget'
 
 export {
   SendWidget,
-  BalancesWidget,
-  TransactionsWidget
+  BalancesWidget
 }

--- a/src/dao/AbstractProxyDAO.js
+++ b/src/dao/AbstractProxyDAO.js
@@ -74,7 +74,7 @@ class AbstractProxyDAO extends AbstractContractDAO {
           symbol
         })
       }
-      if ((tx.args.to === account || tx.args.from === account) && tx.args.value > 0) {
+      if ((account === 'all' || tx.args.to === account || tx.args.from === account) && tx.args.value > 0) {
         if (block && time) {
           return resolve(callback(block, time))
         }

--- a/src/pages/LHStoryPage.js
+++ b/src/pages/LHStoryPage.js
@@ -2,7 +2,8 @@ import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import {Paper, Divider} from 'material-ui'
 import {Table, TableHeader, TableBody, TableHeaderColumn, TableRowColumn, TableRow} from 'material-ui/Table'
-import {listStory} from '../redux/lhStory/lhStory'
+import TransactionsWidget from '../components/common/TransactionsWidget'
+import { listStory, getLHTransactions } from '../redux/lhStory/lhStory'
 import styles from '../styles'
 
 const customStyles = {
@@ -15,6 +16,21 @@ const customStyles = {
     }
   }
 }
+
+const mapStateToPropsWidget = (state) => ({
+  transactions: state.get('lhStory').transactions,
+  toBlock: state.get('lhStory').toBlock,
+  isFetching: state.get('lhStory').isFetching,
+  title: 'LHT Transactions from all accounts'
+})
+
+const mapDispatchToPropsWidget = (dispatch) => ({
+  getTransactions: (toBlock = null, isAllLH = false) => {
+    dispatch(getLHTransactions('all', toBlock))
+  }
+})
+
+const ConnectedTransactionsWidget = connect(mapStateToPropsWidget, mapDispatchToPropsWidget)(TransactionsWidget)
 
 const mapStateToProps = (state) => ({
   list: state.get('lhStory').list
@@ -56,6 +72,11 @@ class LHStoryPage extends Component {
             </TableBody>
           </Table>
         </Paper>
+        <div className='row' style={{ marginTop: 20 }}>
+          <div className='col-sm-12'>
+            <ConnectedTransactionsWidget />
+          </div>
+        </div>
       </div>
     )
   }

--- a/src/pages/WalletPage.js
+++ b/src/pages/WalletPage.js
@@ -1,10 +1,24 @@
 import React, {Component} from 'react'
+import { connect } from 'react-redux'
 import {
   SendWidget,
-  BalancesWidget,
-  TransactionsWidget
+  BalancesWidget
 } from '../components/pages/WalletPage'
+import TransactionsWidget from '../components/common/TransactionsWidget'
+import { getTransactionsByAccount } from '../redux/wallet/actions'
 import globalStyles from '../styles'
+
+const mapStateToPropsWidget = (state) => ({
+  transactions: state.get('wallet').transactions,
+  toBlock: state.get('wallet').toBlock,
+  isFetching: state.get('wallet').isFetching
+})
+
+const mapDispatchToPropsWidget = (dispatch) => ({
+  getTransactions: (toBlock = null) => dispatch(getTransactionsByAccount(window.localStorage.account, toBlock))
+})
+
+const ConnectedTransactionsWidget = connect(mapStateToPropsWidget, mapDispatchToPropsWidget)(TransactionsWidget)
 
 class WalletPage extends Component {
   render () {
@@ -21,7 +35,7 @@ class WalletPage extends Component {
         </div>
         <div className='row' style={{marginTop: 20}}>
           <div className='col-sm-12'>
-            <TransactionsWidget />
+            <ConnectedTransactionsWidget />
           </div>
         </div>
       </div>

--- a/src/redux/lhStory/lhStory.js
+++ b/src/redux/lhStory/lhStory.js
@@ -1,10 +1,17 @@
-import {List} from 'immutable'
+import {List, Map} from 'immutable'
+import LHTProxyDAO from '../../dao/LHTProxyDAO'
 import PlatformEmitterDAO from '../../dao/PlatformEmitterDAO'
+import ChronoMintDAO from '../../dao/ChronoMintDAO'
 
 export const LH_STORY_LIST = 'lhStory/LIST'
+export const LH_STORY_TRANSACTIONS_FETCH = 'lhStory/TRANSACTIONS_FETCH'
+export const LH_STORY_TRANSACTIONS = 'lhStory/TRANSACTIONS'
 
-const initialState = {
-  list: new List()
+export const initialState = {
+  isFetching: false,
+  list: new List(),
+  transactions: new Map(),
+  toBlock: null
 }
 
 const reducer = (state = initialState, action) => {
@@ -13,6 +20,18 @@ const reducer = (state = initialState, action) => {
       return {
         ...state,
         list: action.list
+      }
+    case LH_STORY_TRANSACTIONS_FETCH:
+      return {
+        ...state,
+        isFetching: true
+      }
+    case LH_STORY_TRANSACTIONS:
+      return {
+        ...state,
+        isFetching: false,
+        transactions: state.transactions.merge(action.map),
+        toBlock: action.toBlock
       }
     default:
       return state
@@ -32,8 +51,28 @@ const listStory = () => (dispatch) => {
   dispatch({type: LH_STORY_LIST, list})
 }
 
+const getLHTransactions = (account, toBlock) => (dispatch) => {
+  dispatch({ type: LH_STORY_TRANSACTIONS_FETCH })
+
+  const callback = (toBlock) => {
+    const fromBlock = toBlock - 100 < 0 ? 0 : toBlock - 100
+    LHTProxyDAO.getTransfer(account, fromBlock, toBlock).then(values => {
+      dispatch({ type: LH_STORY_TRANSACTIONS, map: values, toBlock: fromBlock - 1 })
+    })
+  }
+
+  if (!toBlock) {
+    ChronoMintDAO.web3.eth.getBlockNumber((e, r) => {
+      callback(e ? 0 : r)
+    })
+  } else {
+    callback(toBlock)
+  }
+}
+
 export {
-  listStory
+  listStory,
+  getLHTransactions
 }
 
 export default reducer


### PR DESCRIPTION
- moving TransactionsWidget.js from wallet to components/common for using it in both wallet and LHStoryPage.
- moving connect TransactionsWidget to redux to corresponding pages

Sorting of columns will come at material-ui 1.0 version. it already in beta 1.0.Pre-release but better wait for release then writing bicycle