### PR TITLE
MINT-394 Fix topbar markup for mobile version

### DIFF
--- a/src/layouts/partials/BrandPartial.scss
+++ b/src/layouts/partials/BrandPartial.scss
@@ -16,7 +16,7 @@
     display: flex;
     align-items: center;
     flex-direction: row;
-    flex-wrap: wrap;
+    flex-wrap: nowrap; 
 
     .heading {
       flex: 0 0 auto;

--- a/src/layouts/partials/HeaderPartial.scss
+++ b/src/layouts/partials/HeaderPartial.scss
@@ -60,6 +60,13 @@ $default-padding: 8px 0px;
     padding: 10px 15px;
     overflow: hidden;
     margin-left: auto;
+    @media (max-width: 480px) {
+      // Not "display: none" because in this case some spacer is needed and that
+      // is not semantic
+      opacity: 0;
+      height: 0;
+      pointer-events: none; 
+    }
 
     .info {
       font-size: 16px;


### PR DESCRIPTION
On mobile devices (<= 480px width) account info in header is hidden. Fixed two rows with logo and language select.