### PR TITLE
[WIP] Login package: Added required dependency

### DIFF
--- a/packages/login/package.json
+++ b/packages/login/package.json
@@ -4,6 +4,7 @@
   "author": "chronobank",
   "license": "AGPL-3.0",
   "dependencies": {
-    "ledger-wallet-provider": "github:mikefluff/ledger-wallet-provider"
+    "ledger-wallet-provider": "github:mikefluff/ledger-wallet-provider",
+    "@waves/waves-api": "0.28.2"
   }
 }


### PR DESCRIPTION
We can't use packages/login in ChronoMint mobile without this dependency.

After discussion with Ivan decided to keep 'waves/waves-api': '0.28.2' in the root package.json for further development (it will be used in the future)