### PR TITLE
Replaced Node.js 'require' to ES6 'export..from'

### DIFF
--- a/packages/core/dao/abi/index.js
+++ b/packages/core/dao/abi/index.js
@@ -3,30 +3,29 @@
  * Licensed under the AGPL Version 3 license.
  */
 
-/* eslint-disable */
-export const ChronoBankPlatformABI = require('chronobank-smart-contracts/build/contracts/ChronoBankPlatform.json')
-export const MultiEventsHistoryABI = require('chronobank-smart-contracts/build/contracts/MultiEventsHistory.json')
-export const WalletABI = require('chronobank-smart-contracts/build/contracts/Wallet.json')
-export const ContractsManagerABI = require('chronobank-smart-contracts/build/contracts/ContractsManager.json')
-export const ERC20ManagerABI = require('chronobank-smart-contracts/build/contracts/ERC20Manager.json')
-export const ExchangeABI = require('chronobank-smart-contracts/build/contracts/Exchange.json')
-export const ExchangeManagerABI = require('chronobank-smart-contracts/build/contracts/ExchangeManager')
-export const FakeCoinABI = require('chronobank-smart-contracts/build/contracts/FakeCoin.json')
-export const FeeInterfaceABI = require('chronobank-smart-contracts/build/contracts/FeeInterface.json')
-export const ChronoBankAssetWithFeeProxyABI = require('chronobank-smart-contracts/build/contracts/ChronoBankAssetWithFeeProxy.json')
-export const LOCManagerABI = require('chronobank-smart-contracts/build/contracts/LOCManager.json')
-export const PendingManagerABI = require('chronobank-smart-contracts/build/contracts/PendingManager.json')
-export const PlatformsManagerABI = require('chronobank-smart-contracts/build/contracts/PlatformsManager.json')
-export const PlatformTokenExtensionGatewayManagerEmitterABI = require('chronobank-smart-contracts/build/contracts/PlatformTokenExtensionGatewayManagerEmitter.json')
-export const RewardsABI = require('chronobank-smart-contracts/build/contracts/Rewards.json')
-export const AssetHolderABI = require('chronobank-smart-contracts/build/contracts/TimeHolder.json')
-export const TokenManagementInterfaceABI = require('chronobank-smart-contracts/build/contracts/TokenManagementInterface.json')
-export const UserManagerABI = require('chronobank-smart-contracts/build/contracts/UserManager.json')
-export const VotingManagerABI = require('chronobank-smart-contracts/build/contracts/VotingManager.json')
-export const PollEmitterABI = require('chronobank-smart-contracts/build/contracts/PollEmitter')
-export const PollInterfaceABI = require('chronobank-smart-contracts/build/contracts/PollInterface.json')
-export const WalletsManagerABI = require('chronobank-smart-contracts/build/contracts/WalletsManager.json')
-export const AssetDonatorABI = require('chronobank-smart-contracts/build/contracts/AssetDonator.json')
-export const ChronoBankAssetProxyABI = require('chronobank-smart-contracts/build/contracts/ChronoBankAssetProxy.json')
-export const AssetsManagerABI = require('chronobank-smart-contracts/build/contracts/AssetsManager.json')
-export const ChronoBankAssetABI = require('chronobank-smart-contracts/build/contracts/ChronoBankAsset.json')
+export { default as ChronoBankPlatformABI } from 'chronobank-smart-contracts/build/contracts/ChronoBankPlatform.json'
+export { default as MultiEventsHistoryABI } from 'chronobank-smart-contracts/build/contracts/MultiEventsHistory.json'
+export { default as WalletABI } from 'chronobank-smart-contracts/build/contracts/Wallet.json'
+export { default as ContractsManagerABI } from 'chronobank-smart-contracts/build/contracts/ContractsManager.json'
+export { default as ERC20ManagerABI } from 'chronobank-smart-contracts/build/contracts/ERC20Manager.json'
+export { default as ExchangeABI } from 'chronobank-smart-contracts/build/contracts/Exchange.json'
+export { default as ExchangeManagerABI } from 'chronobank-smart-contracts/build/contracts/ExchangeManager'
+export { default as FakeCoinABI } from 'chronobank-smart-contracts/build/contracts/FakeCoin.json'
+export { default as FeeInterfaceABI } from 'chronobank-smart-contracts/build/contracts/FeeInterface.json'
+export { default as ChronoBankAssetWithFeeProxyABI } from 'chronobank-smart-contracts/build/contracts/ChronoBankAssetWithFeeProxy.json'
+export { default as LOCManagerABI } from 'chronobank-smart-contracts/build/contracts/LOCManager.json'
+export { default as PendingManagerABI } from 'chronobank-smart-contracts/build/contracts/PendingManager.json'
+export { default as PlatformsManagerABI } from 'chronobank-smart-contracts/build/contracts/PlatformsManager.json'
+export { default as PlatformTokenExtensionGatewayManagerEmitterABI } from 'chronobank-smart-contracts/build/contracts/PlatformTokenExtensionGatewayManagerEmitter.json'
+export { default as RewardsABI } from 'chronobank-smart-contracts/build/contracts/Rewards.json'
+export { default as AssetHolderABI } from 'chronobank-smart-contracts/build/contracts/TimeHolder.json'
+export { default as TokenManagementInterfaceABI } from 'chronobank-smart-contracts/build/contracts/TokenManagementInterface.json'
+export { default as UserManagerABI } from 'chronobank-smart-contracts/build/contracts/UserManager.json'
+export { default as VotingManagerABI } from 'chronobank-smart-contracts/build/contracts/VotingManager.json'
+export { default as PollEmitterABI } from 'chronobank-smart-contracts/build/contracts/PollEmitter'
+export { default as PollInterfaceABI } from 'chronobank-smart-contracts/build/contracts/PollInterface.json'
+export { default as WalletsManagerABI } from 'chronobank-smart-contracts/build/contracts/WalletsManager.json'
+export { default as AssetDonatorABI } from 'chronobank-smart-contracts/build/contracts/AssetDonator.json'
+export { default as ChronoBankAssetProxyABI } from 'chronobank-smart-contracts/build/contracts/ChronoBankAssetProxy.json'
+export { default as AssetsManagerABI } from 'chronobank-smart-contracts/build/contracts/AssetsManager.json'
+export { default as ChronoBankAssetABI } from 'chronobank-smart-contracts/build/contracts/ChronoBankAsset.json'


### PR DESCRIPTION
Please do not use 'require' in the source code of a frontend. 
'require' is suitable only for images in our project.