### PR TITLE
CM-111: fixed getting fiat prices from min-api.cryptocompare.com

### DIFF
--- a/packages/core/redux/market/actions.js
+++ b/packages/core/redux/market/actions.js
@@ -17,6 +17,7 @@ import {
 import { chunker } from './utils'
 
 const MARKET_REQUEST_DELAY = 30000
+const MAX_FSYMS_LENGTH = 300 // Max length of a string of comma-spearated tokens. See API at https://min-api.cryptocompare.com/
 
 // TODO: to check, why we need this mutable variable exported
 // eslint-disable-next-line import/no-mutable-exports
@@ -30,7 +31,7 @@ const watchMarket = (dispatch, getState) => async () => {
   let response = {}
   const tokenList = tokens.join(',')
   const currencyList = currencies.join(',')
-  if (tokenList.length > 300) {
+  if (tokenList.length > MAX_FSYMS_LENGTH) {
     const chunks = chunker(tokens)
     const chunkedResponse = await Promise.all(
       chunks.map((chunk) => axios.get(`https://min-api.cryptocompare.com/data/pricemulti?fsyms=${chunk.join(',')}&tsyms=${currencyList}`))
@@ -40,7 +41,10 @@ const watchMarket = (dispatch, getState) => async () => {
   } else {
     response = await axios.get(`https://min-api.cryptocompare.com/data/pricemulti?fsyms=${tokenList}&tsyms=${currencyList}`)
   }
-  Object.keys(response.data).length && dispatch({ type: MARKET_UPDATE_PRICES, prices: response.data })
+
+  if (response.data && Object.keys(response.data).length) {
+    dispatch({ type: MARKET_UPDATE_PRICES, prices: response.data })
+  }
 }
 
 export const watchInitMarket = () => (dispatch, getState) => {

--- a/packages/core/redux/market/utils.js
+++ b/packages/core/redux/market/utils.js
@@ -6,24 +6,29 @@
 // eslint-disable-next-line import/prefer-default-export
 export const chunker = (tokens) => {
 
-  const chunk = (list, chunkSize = 5) => {
+  // chunkSize is 35 by default. Lenght of a token may be 3 or 6 characters (especially in testnet)
+  // 3*35 or 6*35 = ~200 or ~300 characters in comma separated string
+  const chunk = (list, requiredChunkSize = 35) => {
     if (!list || !list.length) {
       return []
     }
 
-    let i, j, t
-    const chunks = []
-    for (i = 0, j = list.length; i < j; i += chunkSize) {
-      t = list.slice(i, i + chunkSize)
-      chunks.push(t)
+    // Let's limit chunks size to 35 due to the reasons in comment above
+    const chunkSize = requiredChunkSize > 35 ? 35 : requiredChunkSize
+    let chunkStartIndex, allTokensLength, singleChunk
+    const chunks = [] // array of arrays (chunks)
+
+    for (chunkStartIndex = 0, allTokensLength = list.length; chunkStartIndex < allTokensLength; chunkStartIndex += chunkSize) {
+      singleChunk = list.slice(chunkStartIndex, chunkStartIndex + chunkSize)
+      chunks.push(singleChunk)
     }
 
     return chunks
   }
 
-  const tokenList = tokens.join(',')
-  const tLength = tokenList.length // length of comma-separated string of tokens
+  const tLength = tokens.join(',').length // length of comma-separated string of tokens
   const chunkCount = tLength > 600 ? 3 : 2 // amount of chunks required
-  const chunks = chunk(tokens, Math.ceil(tokens.length/chunkCount))
+  const requiredChunkSize =  Math.ceil(tokens.length/chunkCount)
+  const chunks = chunk(tokens, requiredChunkSize)
   return chunks
 }

--- a/packages/core/redux/market/utils.js
+++ b/packages/core/redux/market/utils.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2017–2018, LaborX PTY
+ * Licensed under the AGPL Version 3 license.
+ */
+
+// eslint-disable-next-line import/prefer-default-export
+export const chunker = (tokens) => {
+
+  const chunk = (list, chunkSize = 5) => {
+    if (!list || !list.length) {
+      return []
+    }
+
+    let i, j, t
+    const chunks = []
+    for (i = 0, j = list.length; i < j; i += chunkSize) {
+      t = list.slice(i, i + chunkSize)
+      chunks.push(t)
+    }
+
+    return chunks
+  }
+
+  const tokenList = tokens.join(',')
+  const tLength = tokenList.length // length of comma-separated string of tokens
+  const chunkCount = tLength > 600 ? 3 : 2 // amount of chunks required
+  const chunks = chunk(tokens, Math.ceil(tokens.length/chunkCount))
+  return chunks
+}

--- a/packages/core/redux/market/utils.js
+++ b/packages/core/redux/market/utils.js
@@ -3,18 +3,20 @@
  * Licensed under the AGPL Version 3 license.
  */
 
+// MAX_CHUNK_SIZE is 35 by default. Length of a token may be 3 or 6 characters (especially in testnet)
+// 3*35 or 6*35 = ~200 or ~300 characters in comma-separated string
+const MAX_CHUNK_SIZE = 35
+
 // eslint-disable-next-line import/prefer-default-export
 export const chunker = (tokens) => {
 
-  // chunkSize is 35 by default. Lenght of a token may be 3 or 6 characters (especially in testnet)
-  // 3*35 or 6*35 = ~200 or ~300 characters in comma separated string
-  const chunk = (list, requiredChunkSize = 35) => {
+  const chunk = (list, requiredChunkSize = MAX_CHUNK_SIZE) => {
     if (!list || !list.length) {
       return []
     }
 
     // Let's limit chunks size to 35 due to the reasons in comment above
-    const chunkSize = requiredChunkSize > 35 ? 35 : requiredChunkSize
+    const chunkSize = requiredChunkSize > MAX_CHUNK_SIZE ? MAX_CHUNK_SIZE : requiredChunkSize
     let chunkStartIndex, allTokensLength, singleChunk
     const chunks = [] // array of arrays (chunks)
 


### PR DESCRIPTION
There is API limitation: fsyms - Comma separated cryptocurrency symbols list [Max character length: 300]
Link: https://min-api.cryptocompare.com/ (tab "Multiple Symbols Price")

This PR fixing this error: 
![screen shot 2018-08-23 at 15 26 03](https://user-images.githubusercontent.com/661889/44568211-82625380-a77e-11e8-9dec-9cb8efbde3d4.png)
